### PR TITLE
Import data

### DIFF
--- a/file_document_import_data/__init__.py
+++ b/file_document_import_data/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#   account_statement_file_document for OpenERP
+#   Copyright (C) 2016-TODAY Akretion <http://www.akretion.com>.
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import file_document

--- a/file_document_import_data/__openerp__.py
+++ b/file_document_import_data/__openerp__.py
@@ -24,7 +24,9 @@
     'version': '0.1',
     'category': 'Generic Modules/Others',
     'license': 'AGPL-3',
-    'description': """empty""",
+    'description': """
+        Allow to make a native odoo import from a file document.
+    """,
     'author': 'Akretion',
     'website': 'http://www.akretion.com/',
     'depends': ['base_import', 'file_document'],

--- a/file_document_import_data/__openerp__.py
+++ b/file_document_import_data/__openerp__.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#   account_statement_file_document for OpenERP
+#   Copyright (C) 2016-TODAY Akretion <http://www.akretion.com>.
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'File Document Import Data',
+    'version': '0.1',
+    'category': 'Generic Modules/Others',
+    'license': 'AGPL-3',
+    'description': """empty""",
+    'author': 'Akretion',
+    'website': 'http://www.akretion.com/',
+    'depends': ['base_import', 'file_document'],
+    'init_xml': [],
+    'update_xml': [
+        'file_document_view.xml',
+    ],
+    'demo_xml': [],
+    'installable': True,
+    'active': False,
+}

--- a/file_document_import_data/file_document.py
+++ b/file_document_import_data/file_document.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#   account_statement_file_document for OpenERP
+#   Copyright (C) 2016-TODAY Akretion <http://www.akretion.com>.
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import fields, orm
+import base64
+
+
+class FileDocument(orm.Model):
+    _inherit = "file.document"
+
+    def get_file_document_type(self, cr, uid, context=None):
+        res = super(FileDocument, self).get_file_document_type(
+            cr, uid, context=context)
+        res.append(('import_data', 'Import Data'))
+        return res
+
+    _columns = {
+        'import_model': fields.char('Model')
+    }
+
+    def get_import_file_format(self, cr, uid, context=None):
+        return {
+            'headers': True,
+            'quoting': '"',
+            'separator': ',',
+            'encoding': 'utf-8'
+        }
+
+    def _run(self, cr, uid, filedocument, context=None):
+        if context is None:
+            context = {}
+        super(FileDocument, self)._run(cr, uid, filedocument, context=context)
+        import_obj = self.pool['base_import.import']
+        if filedocument.file_type == 'import_data':
+            options = self.get_import_file_format(cr, uid, context=context)
+
+            import_vals = {
+                'res_model': filedocument.import_model,
+                'file': base64.b64decode(filedocument.datas),
+                'file_name': filedocument.datas_fname,
+            }
+            import_wizard_id = import_obj.create(
+                cr, uid, import_vals, context=context)
+            parse_datas = import_obj.parse_preview(
+                cr, uid, import_wizard_id, options, count=10, context=context)
+            fields = map(lambda (k, v): v and v[0] or False,
+                parse_datas['matches'].iteritems())
+            messages = import_obj.do(cr, uid, import_wizard_id, fields,
+                    options, dryrun=False, context=context)
+            if messages:
+                messages = [str(rec) for rec in messages]
+                raise orm.except_orm('Import Data error', '\n'.join(messages))
+        return

--- a/file_document_import_data/file_document.py
+++ b/file_document_import_data/file_document.py
@@ -33,7 +33,7 @@ class FileDocument(orm.Model):
         return res
 
     _columns = {
-        'import_model': fields.char('Model')
+        'import_model': fields.many2one('ir.model', 'Model')
     }
 
     def get_import_file_format(self, cr, uid, context=None):
@@ -53,7 +53,7 @@ class FileDocument(orm.Model):
             options = self.get_import_file_format(cr, uid, context=context)
 
             import_vals = {
-                'res_model': filedocument.import_model,
+                'res_model': filedocument.import_model.model,
                 'file': base64.b64decode(filedocument.datas),
                 'file_name': filedocument.datas_fname,
             }

--- a/file_document_import_data/file_document_view.xml
+++ b/file_document_import_data/file_document_view.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <!-- INHERITED VIEW FOR THE OBJECT : file_document -->
+
+        <record id="import_data_file_document_view_form" model="ir.ui.view">
+            <field name="name">import.data.file.document.view_form</field>
+            <field name="model">file.document</field>
+            <field name="inherit_id" ref="file_document.file_document_view_form" />
+            <field name="arch" type="xml">
+                <data>
+                    <field name="file_type" position="after">
+                        <field name="import_model"
+                               attrs="{'invisible':[('file_type', '!=', 'import_data')],
+                                       'required':[('file_type', '=', 'import_data')]}"/>
+                    </field>
+                </data>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/file_repository_import_data/__init__.py
+++ b/file_repository_import_data/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#   account_statement_file_document for OpenERP
+#   Copyright (C) 2016-TODAY Akretion <http://www.akretion.com>.
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import abstract_task
+from . import file_repository

--- a/file_repository_import_data/__openerp__.py
+++ b/file_repository_import_data/__openerp__.py
@@ -26,6 +26,9 @@
     'category': 'Generic Modules/Others',
     'license': 'AGPL-3',
     'description': """
+        Add a type on repository task in order to pass it to file document
+        and be able to do a odoo native import from a file on a distant
+        server.
     """,
     'author': 'Akretion',
     'website': 'http://www.akretion.com/',

--- a/file_repository_import_data/__openerp__.py
+++ b/file_repository_import_data/__openerp__.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#   account_statement_file_document for OpenERP
+#   Copyright (C) 2016-TODAY Akretion <http://www.akretion.com>.
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+{
+    'name': 'File Repository Import Data',
+    'version': '0.1',
+    'category': 'Generic Modules/Others',
+    'license': 'AGPL-3',
+    'description': """
+    """,
+    'author': 'Akretion',
+    'website': 'http://www.akretion.com/',
+    'depends': ['file_repository',
+                'file_document_import_data',
+                ],
+    'demo': [],
+    'data': [
+           'file_repository_view.xml',
+    ],
+    'installable': True,
+    'active': False,
+}

--- a/file_repository_import_data/abstract_task.py
+++ b/file_repository_import_data/abstract_task.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#   account_statement_file_document for OpenERP
+#   Copyright (C) 2016-TODAY Akretion <http://www.akretion.com>.
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm
+
+
+class AutomaticTask(orm.Model):
+    _inherit = "automatic.task"
+
+    def get_task_type(self, cr, uid, context=None):
+        res = super(AutomaticTask, self).get_task_type(cr, uid,
+                                                       context=context)
+        res.append(('import_data', 'Import Data'))
+        return res

--- a/file_repository_import_data/file_repository.py
+++ b/file_repository_import_data/file_repository.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#   account_statement_file_document for OpenERP
+#   Copyright (C) 2016-TODAY Akretion <http://www.akretion.com>.
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import fields, orm
+
+
+class RepositoryTask(orm.Model):
+    _inherit = "repository.task"
+
+    _columns = {
+        'import_model': fields.char('Model')
+    }
+
+    def prepare_document_vals(self, cr, uid, task, file_name, datas,
+                              context=None):
+        vals = super(RepositoryTask, self).prepare_document_vals(
+            cr, uid, task, file_name, datas, context=context)
+        if task.type == 'import_data':
+            vals.update({'file_type': task.type,
+                         'import_model': task.import_model})
+        return vals

--- a/file_repository_import_data/file_repository.py
+++ b/file_repository_import_data/file_repository.py
@@ -26,7 +26,7 @@ class RepositoryTask(orm.Model):
     _inherit = "repository.task"
 
     _columns = {
-        'import_model': fields.char('Model')
+        'import_model': fields.many2one('ir.model', 'Model')
     }
 
     def prepare_document_vals(self, cr, uid, task, file_name, datas,
@@ -35,5 +35,5 @@ class RepositoryTask(orm.Model):
             cr, uid, task, file_name, datas, context=context)
         if task.type == 'import_data':
             vals.update({'file_type': task.type,
-                         'import_model': task.import_model})
+                         'import_model': task.import_model.id})
         return vals

--- a/file_repository_import_data/file_repository_view.xml
+++ b/file_repository_import_data/file_repository_view.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <!-- INHERITED VIEW FOR THE OBJECT : repository_task -->
+
+        <record id="view_import_data_repository_task_form" model="ir.ui.view">
+            <field name="name">import.data.repository.task.view_form</field>
+            <field name="model">repository.task</field>
+            <field name="inherit_id" ref="file_repository.view_repository_task_form" />
+            <field name="arch" type="xml">
+                <data>
+                    <field name="active" position="after">
+                        <field name="import_model"
+                               attrs="{'invisible':[('type', '!=', 'import_data')],
+                                       'required':[('type', '=', 'import_data')]}"/>
+                    </field>
+                </data>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
Hi,

I would like to add two modules, quite simples.
The purpose is to be able to import a file in OpenERP using sftp/ftp.

The goal of module file_repository_import_data is just to add field in order to pass it to file document.
The goal of file_document_import_data is to add field to file documents and add  a type, which is used to import a file.

It's more experimenting modules for now, but I think we can add it to the main 7.0 branch since it adds totally separated modules.

The module file_document_import_data is very simple, and only handle one csv format, the same as the one OpenERP give when we make an export.
Also, the csv file has to be perfect, with the right column names, etc...

The customer which need these modules don't need more complicated stuff for now, but maybe later it will need to be improved.
I could then add a format field on repository/file document object, and think of a way to map column names with fields names.

Remarks are welcome
@sebastienbeau @bealdav 
